### PR TITLE
Fix poll rate helper for Siemens project

### DIFF
--- a/vNode.SiemensS7/Helper/PollRateHelper.cs
+++ b/vNode.SiemensS7/Helper/PollRateHelper.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Text.Json;
-using System.Threading.Tasks;
+using SiemensModule.TagConfig;
+using vNode.Sdk.Data;
 
 namespace vNode.SiemensS7.Helper
 {
@@ -25,7 +23,12 @@ namespace vNode.SiemensS7.Helper
 
             try
             {
-                ModbusTagConfig? cfg = JsonSerializer.Deserialize<ModbusTagConfig>(tag.Config);
+                var options = new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                };
+
+                SiemensTagConfig? cfg = JsonSerializer.Deserialize<SiemensTagConfig>(tag.Config, options);
                 if (cfg == null || cfg.PollRate < 0)
                 {
                     return false;


### PR DESCRIPTION
## Summary
- adjust PollRateHelper to parse using SiemensTagConfig
- ensure property names are case-insensitive in deserialization

## Testing
- `dotnet build vNode.SiemensS7/vNode.SiemensS7.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68653d63edfc832b9b0958b8d567f7e6