### PR TITLE
Fix factory channel class references

### DIFF
--- a/vNode.SiemensS7/SiemensControl.cs
+++ b/vNode.SiemensS7/SiemensControl.cs
@@ -118,9 +118,7 @@ namespace SiemensModule
             InvokeOnPostNewEvent(new RawData(value, QualityCodeOptions.Good_Non_Specific, idTag));
         }   
 
-        private async Task 
-
-        // Implementing RegisterTag method  
+        // Implementing RegisterTag method
         public override bool RegisterTag(TagModelBase tagObject)
         {
             // Add logic to register the tag  
@@ -133,5 +131,4 @@ namespace SiemensModule
             // Add logic to stop the channel  
             return true; // Placeholder implementation  
         }
-    }
-}
+    }}

--- a/vNode.SiemensS7/SiemensFactory.cs
+++ b/vNode.SiemensS7/SiemensFactory.cs
@@ -1,4 +1,5 @@
-﻿using SiemensModule;
+using SiemensModule;
+using System.Text.Json.Nodes;
 using vNode.Sdk.Base;
 using vNode.Sdk.Data;
 using vNode.Sdk.Logger;
@@ -7,12 +8,12 @@ namespace vNode.SiemensS7
 {
     public class SiemensFactory : BaseChannelFactory
     {
-        private SiemensControl _logger;
+        private SiemensControl? _control;
 
-        //TODO: Es necesario?
+        // Inicializa el control del módulo
         public override void InitializeControlChannel(ISdkLogger logger)
         {
-             _logger = new SiemensControl(logger);
+            _control = new SiemensControl(logger);
         }
 
         public override string GetModuleName()
@@ -22,14 +23,15 @@ namespace vNode.SiemensS7
 
         public override BaseChannelControl CreateBaseChannelControl(ISdkLogger logger)
         {
-            // Implement logic for creating BaseChannelControl  
-            return new SiemensChannelControl(logger);
+            // Crea la instancia de control del canal
+            return _control ?? new SiemensControl(logger);
         }
 
         public override BaseChannel CreateBaseChannel(string nodeName, string config, ISdkLogger loggerEx)
         {
-            // Implement logic for creating BaseChannel  
-            return new SiemensChannel(nodeName, config, loggerEx);
+            // Crea una nueva instancia del canal Siemens
+            var json = JsonNode.Parse(config) as JsonObject ?? new JsonObject();
+            return new Siemens(nodeName, json, loggerEx, _control ?? new SiemensControl(loggerEx));
         }
 
         public override string GetChannelSchema()
@@ -70,14 +72,8 @@ namespace vNode.SiemensS7
 
         public override string SanitizeChannelConfiguration(string configuration)
         {
-            // Implement logic to sanitize channel configuration  
+            // Implement logic to sanitize channel configuration
             return configuration.Trim();
-        }
-
-        public override void InitializeControlChannel(ISdkLogger logger)
-        {
-            // Implement logic to initialize control channel  
-            logger.LogInfo("Control channel initialized.");
         }
     }
 }


### PR DESCRIPTION
## Summary
- use `SiemensControl` and `Siemens` classes in `SiemensFactory`
- remove duplicate `InitializeControlChannel` implementation
- drop stray code in `SiemensControl`

## Testing
- `dotnet build vNode.SiemensS7.sln -nologo` *(fails: vNode.Sdk.dll missing)*

------
https://chatgpt.com/codex/tasks/task_e_686e51b57cfc832b936c0d0620ace357