### PR TITLE
Update PollRateHelper using directive

### DIFF
--- a/vNode.SiemensS7/Helper/PollRateHelper.cs
+++ b/vNode.SiemensS7/Helper/PollRateHelper.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Text.Json;
-using SiemensModule.TagConfig;
+using vNode.SiemensS7.TagConfig;
 using vNode.Sdk.Data;
 
 namespace vNode.SiemensS7.Helper


### PR DESCRIPTION
## Summary
- correct namespace for SiemensTagConfig in PollRateHelper

## Testing
- `dotnet build vNode.SiemensS7.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e51b8f158832b911a324500dce219