### PR TITLE
Fix syntax error in SiemensControl

### DIFF
--- a/vNode.SiemensS7/SiemensControl.cs
+++ b/vNode.SiemensS7/SiemensControl.cs
@@ -118,9 +118,7 @@ namespace SiemensModule
             InvokeOnPostNewEvent(new RawData(value, QualityCodeOptions.Good_Non_Specific, idTag));
         }   
 
-        private async Task 
-
-        // Implementing RegisterTag method  
+        // Implementing RegisterTag method
         public override bool RegisterTag(TagModelBase tagObject)
         {
             // Add logic to register the tag  
@@ -133,5 +131,4 @@ namespace SiemensModule
             // Add logic to stop the channel  
             return true; // Placeholder implementation  
         }
-    }
-}
+    }}


### PR DESCRIPTION
## Summary
- remove an unfinished `private async Task` declaration in **SiemensControl.cs**

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e51baa68c832b8c4127108ce8dc20