### PR TITLE
Update success mapping for new TagReadResultItem signature

### DIFF
--- a/vNode.SiemensS7/TagReader/SiemensTagReader.cs
+++ b/vNode.SiemensS7/TagReader/SiemensTagReader.cs
@@ -126,9 +126,14 @@ namespace vNode.SiemensS7.TagReader
                     var quality = s7Result.IsGood ? QualityCodeOptions.Good_Non_Specific : QualityCodeOptions.Bad_Non_Specific;
 
                     // Use CreateSuccess to create a successful TagReadResult.
+                    var batchItem = new TagReadBatchItem(null!, DateTime.UtcNow)
+                    {
+                        ActualReadTime = DateTime.UtcNow
+                    };
+
                     results[tagId] = TagReadResult.CreateSuccess(new List<TagReadResultItem>
                     {
-                        new TagReadResultItem(s7Result.Value, quality, DateTime.UtcNow)
+                        new TagReadResultItem(batchItem, TagReadResult.TagReadResultType.Success, s7Result.Value)
                     });
                 }
             }


### PR DESCRIPTION
## Summary
- construct `TagReadResultItem` with `TagReadBatchItem`, `TagReadResultType`, and value
- adjust success mapping in `SiemensTagReader`

## Testing
- `dotnet test vNode.SiemensS7.sln` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686e51c8ebf4832ba7d4d5200a5f9be9